### PR TITLE
set bank number as read only - only 12 is supported

### DIFF
--- a/public/branchinfo.html
+++ b/public/branchinfo.html
@@ -17,7 +17,7 @@
 
 <form action="/getBranchInfo">
   Bank ID:<br>
-  <input type="text" name="bank_id" value="12">
+  <input type="text" name="bank_id" value="12" disabled="disabled">
   <br>
   Branch ID:<br>
   <input type="text" name="branch_id" value="90">


### PR DESCRIPTION
Disabled the input of bank number, as only 12 (Bank Hapoalim) is currently supported.