### PR TITLE
set bank id input to readonly instead of disabled

### DIFF
--- a/public/branchinfo.html
+++ b/public/branchinfo.html
@@ -17,7 +17,7 @@
 
 <form action="/getBranchInfo">
   Bank ID:<br>
-  <input type="text" name="bank_id" value="12" disabled>
+  <input type="text" name="bank_id" value="12" readonly>
   <br>
   Branch ID:<br>
   <input type="text" name="branch_id" value="90">

--- a/public/branchinfo.html
+++ b/public/branchinfo.html
@@ -17,7 +17,7 @@
 
 <form action="/getBranchInfo">
   Bank ID:<br>
-  <input type="text" name="bank_id" value="12">
+  <input type="text" name="bank_id" value="12" disabled>
   <br>
   Branch ID:<br>
   <input type="text" name="branch_id" value="90">


### PR DESCRIPTION
The bank id value is not passed to the server because the bank_id input html control is defined as disabled.
This modification set it to readonly so that the value will be correctly passed to the server